### PR TITLE
ci: GitHub Actions 보안 취약점 수정 (zizmor)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
           persist-credentials: false
 
       - name: Install git-filter-repo
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: git-filter-repo
           version: "1.0"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install git-filter-repo
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -24,7 +26,7 @@ jobs:
           git config --global init.defaultBranch main
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
 
       - name: Publish package
         run: ./gradlew publishToMavenCentral --no-configuration-cache


### PR DESCRIPTION
## 개요

[zizmor](https://github.com/woodruffw/zizmor)로 GitHub Actions 워크플로우 보안 감사를 수행하고 자동 수정 가능한 항목을 적용했습니다.

## 수정 내용

- **unpinned-uses**: 액션 참조를 버전 태그에서 전체 커밋 SHA로 고정
- **artipacked**: `actions/checkout`에 `persist-credentials: false` 추가